### PR TITLE
add attribute to determine whether to start the storm processes or not

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,6 @@
 default[:storm][:deploy][:user] = ::File.exists?("/home/vagrant") ? "vagrant" : "ubuntu"
 default[:storm][:deploy][:group] = ::File.exists?("/home/vagrant") ? "vagrant" : "ubuntu"
+default[:storm][:deploy][:start_processes] = false
 
 default[:storm][:nimbus][:host] = "192.168.42.10"
 default[:storm][:supervisor][:hosts] = [ "192.168.42.20" ]

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -33,7 +33,7 @@ bash "Storm install" do
   cwd "/home/#{node[:storm][:deploy][:user]}"
   code <<-EOH
   mkdir storm-data || true
-  wget http://apache.mirror.iweb.ca/incubator/storm/apache-storm-#{node[:storm][:version]}/apache-storm-#{node[:storm][:version]}.zip
+  wget http://apache.mirror.iweb.ca/storm/apache-storm-#{node[:storm][:version]}/apache-storm-#{node[:storm][:version]}.zip
   unzip apache-storm-#{node[:storm][:version]}.zip
   cd apache-storm-#{node[:storm][:version]}
   EOH

--- a/recipes/drpc.rb
+++ b/recipes/drpc.rb
@@ -17,4 +17,5 @@ bash "Start drpc" do
     nohup apache-storm-#{node[:storm][:version]}/bin/storm drpc >>drpc.log 2>&1 &
   fi
   EOH
+  only_if { node[:storm][:deploy][:start_processes] }
 end

--- a/recipes/nimbus.rb
+++ b/recipes/nimbus.rb
@@ -17,4 +17,5 @@ bash "Start nimbus" do
     nohup apache-storm-#{node[:storm][:version]}/bin/storm nimbus >>nimbus.log 2>&1 &
   fi
   EOH
+  only_if { node[:storm][:deploy][:start_processes] }
 end

--- a/recipes/supervisor.rb
+++ b/recipes/supervisor.rb
@@ -17,4 +17,5 @@ bash "Start supervisor" do
     nohup apache-storm-#{node[:storm][:version]}/bin/storm supervisor >>supervisor.log 2>&1 &
   fi
   EOH
+  only_if { node[:storm][:deploy][:start_processes] }
 end

--- a/recipes/ui.rb
+++ b/recipes/ui.rb
@@ -17,4 +17,5 @@ bash "Start ui" do
     nohup apache-storm-#{node[:storm][:version]}/bin/storm ui >>ui.log 2>&1 &
   fi
   EOH
+  only_if { node[:storm][:deploy][:start_processes] }
 end


### PR DESCRIPTION
Since the storm services should be supervised, default to _not_ starting the storm processes, controlled by an attribute.
